### PR TITLE
Add support for handling page object responses for services using pagination.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -120,7 +120,7 @@ const BatchLoader1 = module.exports = class BatchLoader {
 
     const { collection, elemReqd } = resultTypes[resultType];
 
-    if (resultArray === null) resultArray = [];
+    if (resultArray === null || resultArray === undefined) resultArray = [];
     if (typeof resultArray === 'object' && !Array.isArray(resultArray)) resultArray = [resultArray];
 
     // hash = { '1': {id: 1, bar: 10} } or { '1': [{id: 1, bar: 10}, {id: 1, bar: 11}], 2: [{id: 2, bar: 12}] }
@@ -181,9 +181,15 @@ const BatchLoader1 = module.exports = class BatchLoader {
     const { getKey = rec => rec[id], paramNames, injects } = options;
 
     return context => new BatchLoader(async (keys, context) => {
-      const result = await service.find(makeCallingParams(
+      let result = await service.find(makeCallingParams(
           context, { [id]: { $in: BatchLoader1.getUniqueKeys(keys) } }, paramNames, injects
         ));
+
+      // Add support for pagination object format
+      if (result && !Array.isArray(result) && Array.isArray(result.data)) {
+        result = result.data;
+      }
+
       return BatchLoader1.getResultsByKey(keys, result, getKey, multi ? '[!]' : '!');
     },
       { context }

--- a/lib/index.js
+++ b/lib/index.js
@@ -186,7 +186,7 @@ const BatchLoader1 = module.exports = class BatchLoader {
         ));
 
       // Add support for pagination object format
-      if (result && !Array.isArray(result) && Array.isArray(result.data)) {
+      if (result && result.data) {
         result = result.data;
       }
 

--- a/tests/helpers/make-services.js
+++ b/tests/helpers/make-services.js
@@ -30,9 +30,7 @@ module.exports = {
   makeService,
 };
 
-function makeService (store1, name, options) {
-  const returnPageObject = options && options.returnPageObject;
-
+function makeService (store1, name, options={}) {
   return {
     get (id) {
       //console.log(`... ${name} get ${id}`);
@@ -60,7 +58,7 @@ function makeService (store1, name, options) {
           : value.$in.indexOf(post[field]) !== -1;
       }))
       .then((data) => {
-        if (returnPageObject) {
+        if (options.returnPageObject) {
           /**
            * Simulate the use of Pagination plugin that returns a _page object_
            * https://docs.feathersjs.com/api/databases/common.html#pagination

--- a/tests/helpers/make-services.js
+++ b/tests/helpers/make-services.js
@@ -26,10 +26,12 @@ const usersStore = [
 module.exports = {
   posts: makeService(postsStore, 'posts'),
   comments: makeService(commentsStore, 'comments'),
-  users: makeService(usersStore, 'users')
+  users: makeService(usersStore, 'users'),
+  makeService,
 };
 
-function makeService (store1, name) {
+function makeService (store1, name, options) {
+  const returnPageObject = options && options.returnPageObject;
 
   return {
     get (id) {
@@ -52,11 +54,28 @@ function makeService (store1, name) {
       const field = Object.keys(params.query)[0];
       let value = params.query[field];
 
+
       return asyncReturn(store.filter(post => {
         return typeof value !== 'object'
           ? post[field] === value
           : value.$in.indexOf(post[field]) !== -1;
-      }));
+      }))
+      .then((data) => {
+        if (returnPageObject) {
+          /**
+           * Simulate the use of Pagination plugin that returns a _page object_
+           * https://docs.feathersjs.com/api/databases/common.html#pagination
+           */
+          return {
+            total: data.length,
+            limit: 10,
+            skip: 0,
+            data: data
+          };
+        }
+
+        return data;
+      });
     }
   };
 }

--- a/tests/helpers/make-services.js
+++ b/tests/helpers/make-services.js
@@ -54,7 +54,6 @@ function makeService (store1, name, options) {
       const field = Object.keys(params.query)[0];
       let value = params.query[field];
 
-
       return asyncReturn(store.filter(post => {
         return typeof value !== 'object'
           ? post[field] === value

--- a/tests/loader-factory.test.js
+++ b/tests/loader-factory.test.js
@@ -1,0 +1,34 @@
+
+const { assert } = require('chai');
+const { makeService } = require('./helpers/make-services');
+const { loaderFactory } = require('../lib');
+
+const usersStore = [
+  { id: 101, name: 'Chris' },
+];
+
+describe('loader-factory.test.js', () => {
+
+  it('works without pagination', () => {
+    const users = makeService(usersStore, 'users', { returnPageObject: false });
+    const context = { _loaders: { user: {} } };
+    context._loaders.user.id = loaderFactory(users, 'id', false)(context);
+
+    return context._loaders.user.id.load(101)
+      .then((user) => {
+        assert.deepEqual(usersStore[0], user);
+      });
+  });
+
+  it('works with pagination', () => {
+    const users = makeService(usersStore, 'users', { returnPageObject: true });
+    const context = { _loaders: { user: {} } };
+    context._loaders.user.id = loaderFactory(users, 'id', false)(context);
+
+    return context._loaders.user.id.load(101)
+      .then((user) => {
+        assert.deepEqual(usersStore[0], user);
+      });
+  });
+
+});

--- a/tests/loader-factory.test.js
+++ b/tests/loader-factory.test.js
@@ -14,7 +14,7 @@ describe('loader-factory.test.js', () => {
     const context = { _loaders: { user: {} } };
     context._loaders.user.id = loaderFactory(users, 'id', false)(context);
 
-    return context._loaders.user.id.load(101)
+    return context._loaders.user.id.load(usersStore[0].id)
       .then((user) => {
         assert.deepEqual(usersStore[0], user);
       });
@@ -25,7 +25,7 @@ describe('loader-factory.test.js', () => {
     const context = { _loaders: { user: {} } };
     context._loaders.user.id = loaderFactory(users, 'id', false)(context);
 
-    return context._loaders.user.id.load(101)
+    return context._loaders.user.id.load(usersStore[0].id)
       .then((user) => {
         assert.deepEqual(usersStore[0], user);
       });


### PR DESCRIPTION
Previously, if your service had pagination enabled, the loaderFactory would fail to get service results due to the data array being moved to `response.data` property.

- [x] add loaderFactory support for pagination objects
- [x] add two tests
- [x] extend make-services to simulate pagination response formats

More info from the docs:
"When paginate.default is set, find will return an page object (instead of the normal array) in the following form:" - https://docs.feathersjs.com/api/databases/common.html#pagination

