### PR TITLE
Revert old changes and apply new strategy to add pagination support.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -181,14 +181,9 @@ const BatchLoader1 = module.exports = class BatchLoader {
     const { getKey = rec => rec[id], paramNames, injects } = options;
 
     return context => new BatchLoader(async (keys, context) => {
-      let result = await service.find(makeCallingParams(
+      const result = await service.find(makeCallingParams(
           context, { [id]: { $in: BatchLoader1.getUniqueKeys(keys) } }, paramNames, injects
         ));
-
-      // Add support for pagination object format
-      if (result && result.data) {
-        result = result.data;
-      }
 
       return BatchLoader1.getResultsByKey(keys, result, getKey, multi ? '[!]' : '!');
     },
@@ -292,6 +287,7 @@ function makeCallingParams (
   context, query, include = ['provider', 'authenticated', 'user'], inject = {}
 ) {
   const included = query ? { query } : {};
+  const defaults = { _populate: 'skip', paginate: false };
 
   if (include) {
     (Array.isArray(include) ? include : [include]).forEach(name => {
@@ -299,7 +295,7 @@ function makeCallingParams (
     });
   }
 
-  return Object.assign({ _populate: 'skip' }, included, inject);
+  return Object.assign(defaults, included, inject);
 }
 
 /* shout out to Facebook's GraphQL utilities */

--- a/tests/helpers/make-services.js
+++ b/tests/helpers/make-services.js
@@ -26,11 +26,11 @@ const usersStore = [
 module.exports = {
   posts: makeService(postsStore, 'posts'),
   comments: makeService(commentsStore, 'comments'),
-  users: makeService(usersStore, 'users'),
-  makeService,
+  users: makeService(usersStore, 'users')
 };
 
-function makeService (store1, name, options={}) {
+function makeService (store1, name) {
+
   return {
     get (id) {
       //console.log(`... ${name} get ${id}`);
@@ -56,23 +56,7 @@ function makeService (store1, name, options={}) {
         return typeof value !== 'object'
           ? post[field] === value
           : value.$in.indexOf(post[field]) !== -1;
-      }))
-      .then((data) => {
-        if (options.returnPageObject) {
-          /**
-           * Simulate the use of Pagination plugin that returns a _page object_
-           * https://docs.feathersjs.com/api/databases/common.html#pagination
-           */
-          return {
-            total: data.length,
-            limit: 10,
-            skip: 0,
-            data: data
-          };
-        }
-
-        return data;
-      });
+      }));
     }
   };
 }

--- a/tests/loader-factory.test.js
+++ b/tests/loader-factory.test.js
@@ -1,33 +1,17 @@
 
 const { assert } = require('chai');
-const { makeService } = require('./helpers/make-services');
+const { users } = require('./helpers/make-services');
 const { loaderFactory } = require('../lib');
-
-const usersStore = [
-  { id: 101, name: 'Chris' },
-];
 
 describe('loader-factory.test.js', () => {
 
-  it('works without pagination', () => {
-    const users = makeService(usersStore, 'users', { returnPageObject: false });
+  it('can load an entity', () => {
     const context = { _loaders: { user: {} } };
     context._loaders.user.id = loaderFactory(users, 'id', false)(context);
 
-    return context._loaders.user.id.load(usersStore[0].id)
+    return context._loaders.user.id.load(101)
       .then((user) => {
-        assert.deepEqual(usersStore[0], user);
-      });
-  });
-
-  it('works with pagination', () => {
-    const users = makeService(usersStore, 'users', { returnPageObject: true });
-    const context = { _loaders: { user: {} } };
-    context._loaders.user.id = loaderFactory(users, 'id', false)(context);
-
-    return context._loaders.user.id.load(usersStore[0].id)
-      .then((user) => {
-        assert.deepEqual(usersStore[0], user);
+        assert.deepEqual({ id: 101, name: 'John' }, user);
       });
   });
 


### PR DESCRIPTION
@eddyystop as you alluded to on slack, I feel this is a better solution for adding pagination support. Disable pagination by default for service calls from the loaderFactory.